### PR TITLE
add reverse map iteration

### DIFF
--- a/native/jsont_nif/Cargo.lock
+++ b/native/jsont_nif/Cargo.lock
@@ -131,8 +131,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 [[package]]
 name = "rustler"
 version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75d458f38f550976d0e4b347ca57241c192019777e46af7af73b27783287088"
+source = "git+https://github.com/devsnek/rustler.git?rev=85db85042821396f7d5151a965d1e8233ac7738f#85db85042821396f7d5151a965d1e8233ac7738f"
 dependencies = [
  "lazy_static",
  "rustler_codegen",
@@ -142,8 +141,7 @@ dependencies = [
 [[package]]
 name = "rustler_codegen"
 version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbd46408f51c0ca6a68dc36aa4f90e3554960bd1b7cc513e6ff2ccad7dd92aff"
+source = "git+https://github.com/devsnek/rustler.git?rev=85db85042821396f7d5151a965d1e8233ac7738f#85db85042821396f7d5151a965d1e8233ac7738f"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -153,9 +151,8 @@ dependencies = [
 
 [[package]]
 name = "rustler_sys"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76ba8524729d7c9db2b3e80f2269d1fdef39b5a60624c33fd794797e69b558"
+version = "2.4.0"
+source = "git+https://github.com/devsnek/rustler.git?rev=85db85042821396f7d5151a965d1e8233ac7738f#85db85042821396f7d5151a965d1e8233ac7738f"
 dependencies = [
  "regex",
  "unreachable",

--- a/native/jsont_nif/Cargo.toml
+++ b/native/jsont_nif/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 num-bigint = "0.4.4"
-rustler = "0.31.0"
+rustler = { git = "https://github.com/devsnek/rustler.git", rev = "85db85042821396f7d5151a965d1e8233ac7738f" }
 serde_json = "1.0.111"
 simdutf8 = "0.1.4"
 

--- a/native/jsont_nif/src/encoder.rs
+++ b/native/jsont_nif/src/encoder.rs
@@ -165,6 +165,7 @@ where
 
         let strip_elixir_struct = self.strip_elixir_struct;
         let iter = iter
+            .rev()
             .filter(|pair| {
                 if strip_elixir_struct {
                     __struct__() != pair.0

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -53,7 +53,7 @@ defmodule Jsont.EncoderTest do
     assert to_json(%{}) == "{}"
     assert to_json(%{"foo" => "bar"}) == ~s({"foo":"bar"})
     assert to_json(%{foo: :bar}) == ~s({"foo":"bar"})
-    assert to_json(%{"foo" => "foo1", :foo => "foo2"}) == ~s({"foo":"foo2","foo":"foo1"})
+    assert to_json(%{"foo" => "foo1", :foo => "foo2"}) == ~s({"foo":"foo1","foo":"foo2"})
 
     assert to_json(%{42 => :bar}) == ~s({"42":"bar"})
     assert to_json(%{42 => :bar}, bigint_as_string: true) == ~s({"42":"bar"})
@@ -85,6 +85,7 @@ defmodule Jsont.EncoderTest do
 
     expected =
       Map.keys(struct)
+      |> Enum.reverse()
       |> Enum.map(fn k ->
         v = get_in(struct, [Access.key(k)])
         ~s("#{k}":"#{v}")


### PR DESCRIPTION
maintain compat with jiffy, which copies & *reverses* maps when encoding them