### PR TITLE
use HTTPS for checking out submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "JSONTestSuite"]
 	path = JSONTestSuite
-	url = git@github.com:nst/JSONTestSuite.git
+	url = https://github.com/nst/JSONTestSuite


### PR DESCRIPTION
this is superior to using git-over-ssh:
- it's faster
- it's less prone to failure (github is a Very Reliable Service)